### PR TITLE
Add "." to operator list, so decimal part is highlighted

### DIFF
--- a/userDefineLang.xml
+++ b/userDefineLang.xml
@@ -13,7 +13,7 @@
             <Keywords name="Numbers, suffix1"></Keywords>
             <Keywords name="Numbers, suffix2">i</Keywords>
             <Keywords name="Numbers, range"></Keywords>
-            <Keywords name="Operators1">( ) [ ] { } ... , ; &amp; ^ % &gt; &lt; ! = + - * / | :</Keywords>
+            <Keywords name="Operators1">( ) [ ] { } . , ; &amp; ^ % &gt; &lt; ! = + - * / | :</Keywords>
             <Keywords name="Operators2"></Keywords>
             <Keywords name="Folders in code1, open"></Keywords>
             <Keywords name="Folders in code1, middle"></Keywords>


### PR DESCRIPTION
for example, in `0.0`, the `.0` part isn't highlighted. And "..." are still working, as "." is an operator, three times "." is also highlighted the same
