### PR TITLE
Updated README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Notepad++ keyword auto-completion
 ---------------------------------
 
   1. Given a Notepad++ installation at `<DIR>`.
-  2. Copy `go.xml` to `<DIR>\plugins\APIs`
+  2. Copy `go.xml` to the `<DIR>\autoCompletion` directory
   3. Restart Notepad++
 
 **Reference:**


### PR DESCRIPTION
Auto-completion files have been relocated to "%ProgramFiles%\Notepad++\autoCompletion" in newer versions.

More details can be found here:
https://notepad-plus-plus.org/community/topic/16494/new-built-in-plugin-admin-plugin-manager-is-ready/108